### PR TITLE
Bug Fix: Contact Heading Centering Issue

### DIFF
--- a/contact.html
+++ b/contact.html
@@ -47,7 +47,7 @@ page_title: Contact Us
 								<div class="fbox-icon">
 									<a href="#"><i class="icon-map-marker2"></i></a>
 								</div>
-								<h3>Washington, DC<span class="subtitle"><a href="mailto:erin@seekhealing.org">erin@seakhealing.org</a></span></h3>
+								<h3>Washington, DC<span class="subtitle"><a href="mailto:erin@seekhealing.org">erin@seekhealing.org</a></span></h3>
 							</div>
 						</div>
 
@@ -56,7 +56,7 @@ page_title: Contact Us
 								<div class="fbox-icon">
 									<a href="#"><i class="icon-map-marker2"></i></a>
 								</div>
-								<h3>Nashville, TN<span class="subtitle"><a href="mailto:kyla@seekhealing.org">kyla@seakhealing.org</a></span></h3>
+								<h3>Nashville, TN<span class="subtitle"><a href="mailto:kyla@seekhealing.org">kyla@seekhealing.org</a></span></h3>
 							</div>
 						</div>
 
@@ -65,7 +65,7 @@ page_title: Contact Us
 								<div class="fbox-icon">
 									<a href="#"><i class="icon-map-marker2"></i></a>
 								</div>
-								<h3>Asheville, NC<span class="subtitle"><a href="mailto:jennifer@seekhealing.org">jennifer@seakhealing.org</a></span></h3>
+								<h3>Asheville, NC<span class="subtitle"><a href="mailto:jennifer@seekhealing.org">jennifer@seekhealing.org</a></span></h3>
 							</div>
 						</div>
 
@@ -74,7 +74,7 @@ page_title: Contact Us
 								<div class="fbox-icon">
 									<a href="#"><i class="icon-map-marker2"></i></a>
 								</div>
-								<h3>Columbia, SC<span class="subtitle"><a href="mailto:amanda@seekhealing.org">amanda@seakhealing.org</a></span></h3>
+								<h3>Columbia, SC<span class="subtitle"><a href="mailto:amanda@seekhealing.org">amanda@seekhealing.org</a></span></h3>
 							</div>
 						</div>
 

--- a/contact.html
+++ b/contact.html
@@ -40,7 +40,7 @@ page_title: Contact Us
 						<span class="emphasized-header">Mid Atlantic Region </span>
 						<span class="non-emphasized-header">of the USA </span>
 					</div>
-					<div class="row clear-bottommargin">
+					<div class="row">
 
 						<div class="col-md-3 col-sm-6 bottommargin clearfix">
 							<div class="feature-box fbox-center fbox-bg fbox-plain">


### PR DESCRIPTION
This PR includes a fix for the heading centering issue described in #29 .

## Issue Problem
The problem for this issue is stemming from a class that includes a negative margin that was added to the div above it.  In general, negative margins are not recommended and tend to cause other issues, like the centering issue described in the issue.

## Issue Solution
As described above, the simplest solution that I can think of is to remove the negative margin class from the div above the issue.  

I'm not sure if a negative margin is actually required here?  I actually think the spacing is more consistent and better without the negative margin?  Screen caps below of before fix (with the negative margin) and after the fix (with the negative margin).  If I am mistaken and the spacing should match as it does before the fix, please let me know and we can figure out a different way of tackling this issue.

### Before the fix (current production):
<kbd>
<img width="1164" alt="screen shot 2017-10-08 at 3 25 57 pm" src="https://user-images.githubusercontent.com/2396774/31320228-fa18f15e-ac3e-11e7-95f1-74e638136ec0.png">
</kbd>

### Building the fix included in this PR it would look like this:
<kbd>
<img width="1186" alt="screen shot 2017-10-08 at 3 25 28 pm" src="https://user-images.githubusercontent.com/2396774/31320230-028603c2-ac3f-11e7-8302-01dc4b740b6d.png">
</kbd>

**UPDATE**
Per feedback, pushed 9ef1eb0 that fixed email addresses on this page as well changing "seakhealing" to "seekhealing".  This commit fixes #28.