### PR TITLE
Styling: Changes to rethinking-rehab page

### DIFF
--- a/css/custom.css
+++ b/css/custom.css
@@ -2,6 +2,8 @@
 /***FULL SITE STYLES***/
 /**********************/
 @import url('https://fonts.googleapis.com/css?family=Permanent+Marker');
+@import url('https://fonts.googleapis.com/css?family=Cousine');
+
 body {
 	color: #777;
 }
@@ -37,10 +39,16 @@ p span.p-link {
 /*IMAGE QUOTES*/
 
 .image-quote .sh-quote,
-.image-quote .sh-quote-author,
+.image-quote .sh-quote-author {
+	color: #fff;
+}
 .image-definition .sh-definition-word,
 .image-definition .sh-definition {
-	color: #fff;
+	color: #000;
+	font-size: 14px;
+	font-weight: 300;
+	line-height: 1.4;
+	font-family: 'Cousine';
 }
 .image-quote .sh-quote {
 	width: 80%;
@@ -48,19 +56,17 @@ p span.p-link {
 	position: relative;
 	top: -69px;
 }
-.image-quote .sh-quote p,
-.image-definition .sh-definition-word,
-.image-definition .sh-definition {
+.image-quote .sh-quote p {
 	font-size: 21px;
 	font-weight: 300;
 	line-height: 1.4;
 }
 .image-definition .sh-definition-word {
 	letter-spacing: 1.5px;
-	font-size: 25px;
+	font-size: 18px;
 }
 .image-definition .sh-definition {
-	margin-top: 200px;
+	margin-top: 10px;
 }
 .image-quote .sh-quote-sign{
 	background-repeat: no-repeat;
@@ -256,96 +262,24 @@ section.explanation-text-section .section  {
     font-size: 22px;
 }
 #standardNarrative .sticky-note {
-	width: 300px;
-	height: 250px;
-	margin-left: 25%;
+	max-width: 300px;
+  min-height: 250px;
+	margin: 25px auto;
 	padding: 15px;
 }
-#standardNarrative .sticky-correct-answer{
+#standardNarrative .sticky-correct-answer-heading{
 	margin-top: 50px;
 }
 #standardNarrative .first-sticky,
 #standardNarrative .second-sticky,
-#standardNarrative .third-sticky,
-#standardNarrative .sticky-correct-answer{
-	background: transparent;
-	opacity: 0;
+#standardNarrative .third-sticky {
+	background: rgba(255,0,0,0.2)
 }
-#standardNarrative .slash-left,
-#standardNarrative .slash-right {
-	position: relative;
-	opacity: 0;
+
+#standardNarrative .sticky-correct-answer {
+	background: rgba(75,211,57,0.2)
 }
-#standardNarrative .slash-left {
-	top: -195px;
-}
-#standardNarrative .slash-right {
-	top: -444px;
-}
-#standardNarrative .second-sticky .slash-left {
-	top: -233px;
-}
-#standardNarrative .second-sticky .slash-right {
-	top: -483px;
-}
-#standardNarrative.start .first-sticky {
-    -webkit-animation: stickyNoteZoom 3s ease-out forwards;
-       -moz-animation: stickyNoteZoom 3s ease-out forwards;
-        -ms-animation: stickyNoteZoom 3s ease-out forwards;
-         -o-animation: stickyNoteZoom 3s ease-out forwards;
-            animation: stickyNoteZoom 3s ease-out forwards;
-}
-#standardNarrative.start .second-sticky {
-    -webkit-animation: stickyNoteZoom 3s ease-out 3s forwards;
-       -moz-animation: stickyNoteZoom 3s ease-out 3s forwards;
-        -ms-animation: stickyNoteZoom 3s ease-out 3s forwards;
-         -o-animation: stickyNoteZoom 3s ease-out 3s forwards;
-            animation: stickyNoteZoom 3s ease-out 3s forwards;
-}
-#standardNarrative.start .third-sticky {
-    -webkit-animation: stickyNoteZoom 3s ease-out 6s forwards;
-       -moz-animation: stickyNoteZoom 3s ease-out 6s forwards;
-        -ms-animation: stickyNoteZoom 3s ease-out 6s forwards;
-         -o-animation: stickyNoteZoom 3s ease-out 6s forwards;
-            animation: stickyNoteZoom 3s ease-out 6s forwards;
-}
-#standardNarrative.start .sticky-correct-answer {
-    -webkit-animation: stickyNoteAppear 3s ease-out 6s forwards;
-       -moz-animation: stickyNoteAppear 3s ease-out 6s forwards;
-        -ms-animation: stickyNoteAppear 3s ease-out 6s forwards;
-         -o-animation: stickyNoteAppear 3s ease-out 6s forwards;
-            animation: stickyNoteAppear 3s ease-out 6s forwards;
-}
-#standardNarrative.start .slash-left {
-    -webkit-animation: slashleft 2s ease-out 6s forwards;
-       -moz-animation: slashleft 2s ease-out 6s forwards;
-        -ms-animation: slashleft 2s ease-out 6s forwards;
-         -o-animation: slashleft 2s ease-out 6s forwards;
-            animation: slashleft 2s ease-out 6s forwards;
-}
-#standardNarrative.start .slash-right {
-    -webkit-animation: slashRight 2s ease-out 8s forwards;
-       -moz-animation: slashRight 2s ease-out 8s forwards;
-        -ms-animation: slashRight 2s ease-out 8s forwards;
-         -o-animation: slashRight 2s ease-out 8s forwards;
-            animation: slashRight 2s ease-out 8s forwards;
-}
-@keyframes stickyNoteZoom {
-	from {background-color: transparent; opacity: 0;}
-	to {background-color: #dfcbf7; opacity: 1;}
-}
-@keyframes stickyNoteAppear {
-	from {opacity: 0;}
-	to {opacity: 1;}
-}
-@keyframes slashleft{
-	from{left:-100px;opacity:0} 
-	to{left:0;opacity:1}
-}
-@keyframes slashRight{
-	from{opacity:0} 
-	to{opacity:1}
-}
+
 /***************************/
 /***END STANDARD NARRATIVE**/
 /***************************/
@@ -360,27 +294,21 @@ section.section-image-left, section.section-image-right{
 #longTermHealing .image-right{
 	display: inline-block;
 }
+
+#longTermHealing .image-left,
+#longTermHealing .image-center,
+#longTermHealing .image-right{
+	display: block;
+}
 #longTermHealing .image-caption{
 	max-width: 165px;
-	margin-top: 15px;
+	margin: 15px auto 50px;
 	background-color: #431056;
 	padding: 5px 10px;
 	color: #fff;
 }
-#longTermHealing .image-left {
-	position: relative;
-	left: -45px;
-	top: -45px;
-}
 #longTermHealing .image-center {
-	position: relative;
-	top: 75px;
-	left: 15px;
-}
-#longTermHealing .image-right {
-	position: relative;
-	right: -60px;
-	top: -45px;
+	padding-top: 45px;
 }
 /************************/
 /***END RECENT STUDIES***/
@@ -724,7 +652,9 @@ a.button.button-plan-purple.button-3d:hover {
 	}
 }
 @media(max-width: 768px){
-	
+	#standardNarrative .sticky-note {
+	  min-height: 110px;
+	}
 	.sticky-note-font p {
 	    font-size: 20px;
 	}
@@ -807,6 +737,9 @@ a.button.button-plan-purple.button-3d:hover {
 	}
 	.stick-figure-family {
     	top: -10px;
+	}
+	#longTermHealing .image-center {
+		padding-top: 0px;
 	}
 }
 @media(max-width: 414px){

--- a/rethinking-rehab.html
+++ b/rethinking-rehab.html
@@ -45,22 +45,18 @@ page_title: Rethinking Rehab
 						</span>
 					</div>
 					<div class="row">
-						<div class="col-md-6 col-sm-6 col-xs-6">
+						<div class="col-md-6 col-sm-6 col-xs-12">
 							<div class="sticky-note first-sticky sticky-note-font start">
 								<p>A. A character flaw that comes from laziness and too much partying</p>
-								<img class="slash-left" src="images/slash-left.png"/>
-								<img class="slash-right" src="images/slash-right.png"/>
 							</div>
 						</div>
-						<div class="col-md-6 col-sm-6 col-xs-6">
+						<div class="col-md-6 col-sm-6 col-xs-12">
 							<div class="sticky-note second-sticky sticky-note-font start">
 								<p>B. A disease that hijacks a person's brain and a chemical reality that you cannot change.</p>
-								<img class="slash-left" src="images/slash-left.png"/>
-								<img class="slash-right" src="images/slash-right.png"/>
 							</div>
 						</div>
 					</div>
-					<div class="heading-block center sticky-correct-answer">
+					<div class="heading-block center sticky-correct-answer-heading">
 						<span class="non-emphasized-header">
 							As it turns out,
 						</span>
@@ -75,8 +71,8 @@ page_title: Rethinking Rehab
 						</span>
 					</div>
 					<div class="row">
-						<div class="col-md-6 col-md-offset-3 col-sm-6 col-sm-offset-3 col-xs-6 col-xs-offset-3">
-							<div class="sticky-note third-sticky sticky-note-font">
+						<div class="col-md-6 col-md-offset-3 col-sm-6 col-sm-offset-3 col-xs-12">
+							<div class="sticky-note third-sticky sticky-note-font sticky-correct-answer">
 								<p>C. None of the above</p>
 							</div>
 						</div>
@@ -139,7 +135,7 @@ page_title: Rethinking Rehab
 						</span>
 					</div>
 					<div class="row">
-						<div class="col-md-8 col-md-offset-2 col-sm-8 col-sm-offset-2 col-xs-12 col-xs-offset-2 text-center">
+						<div class="col-md-8 col-md-offset-2 col-sm-8 col-sm-offset-2 col-xs-12 text-center">
 							<p>
 								The people we love who are recovering from opiate or heroin bonds have a limited set of options for their post-detox life, and often even fewer resources available to create and follow plans that lead to sustainable health. Most return to the dysfunctional environments they came from, or find their way into rehab facilities, halfway houses and prisons where they feel lonelier than ever.
 							</p>
@@ -168,19 +164,18 @@ page_title: Rethinking Rehab
 								</span>
 							</div>
 
-							<div class="center bottommargin">
-								<div class="image-left">
+							<div class="row bottommargin">
+								<div class="col-md-4 center">
 									<img src="images/rehab-icon.png" width="135px" height="auto">
 									<p class="image-caption">Rehab</p>
-									
 								</div>
-								<div class="image-center">
+								<div class="col-md-4 center image-center">
 									<img src="images/prison-icon.png" width="135px" height="auto">
 									<p class="image-caption">
 										Prison and/or solitary confinement
 									</p>
 								</div>
-								<div class="image-right">
+								<div class="col-md-4 center">
 									<img src="images/chemical-bond.png" width="135px" height="auto">
 									<p class="image-caption">Methadone clinics</p>
 								</div>
@@ -214,7 +209,7 @@ page_title: Rethinking Rehab
 						<span class="emphasized-header">upside-down </span>
 					</div>
 					<div class="row">
-						<div class="col-md-8 col-md-offset-2 col-sm-8 col-sm-offset-2 col-xs-12 col-xs-offset-2 text-center">
+						<div class="col-md-8 col-md-offset-2 col-sm-8 col-sm-offset-2 col-xs-12 text-center">
 							<p>
 								 Our <a href="project-plan.html">facilities & programs</a>  are intentionally designed to enhance an individual’s experience of connectedness, rather than diagnosing & treating specific problems.
 							</p>
@@ -236,15 +231,7 @@ page_title: Rethinking Rehab
 			<div class="content-wrap">
 				<div class="row clearfix common-height">
 
-					<div class="col-md-6 col-padding" style="background: url('images/seeker-def-image.jpg') center center no-repeat; background-size: cover;">
-						<div class="image-definition">
-							<div class="sh-definition-word">seek &middot; er / ˈsēkər / <em>noun</em>
-							</div>
-							<div class="sh-definition">
-								a person who is actively seeking to become a better human by overcoming unhealthy behaviors, addications, and/or compulsions and their associated emotional triggers.
-							</div>
-						</div>
-					</div>
+					<div class="col-md-6 col-padding" style="background: url('images/seeker-def-image.jpg') center center no-repeat; background-size: cover;"></div>
 
 					<div class="col-md-6 center col-padding" style="background-color: #ffffff;">
 						<div>
@@ -257,6 +244,13 @@ page_title: Rethinking Rehab
 
 							<div class="center bottommargin">
 								<img src="images/owlHeartThoughtBubble-250.png" width="120px" height="auto">
+							</div>
+
+							<div class="image-definition">
+								<div class="sh-definition-word">seek &middot; er / ˈsēkər / <em>noun</em></div>
+								<div class="sh-definition">
+									a person who is actively seeking to become a better human by overcoming unhealthy behaviors, addications, and/or compulsions and their associated emotional triggers.
+								</div>
 							</div>
 						</div>
 					</div>
@@ -279,16 +273,16 @@ page_title: Rethinking Rehab
 							<div class="center bottommargin">
 								<img src="images/owlFriends-h474.png" width="auto" height="150px">
 							</div>
+
+							<div class="image-definition">
+								<div class="sh-definition-word">lis·ten·er / ˈlis(ə)nər / <em>noun</em></div>
+								<div class="sh-definition">
+									a seeker who chooses to help another seeker by intentionally creating a context for authentic interpersonal connection
+								</div>
+							</div>
 						</div>
 					</div>
 					<div class="col-md-6 col-padding" style="background: url('images/recent-studies-background.jpg') center center no-repeat; background-size: cover;">
-						<div class="image-definition">
-							<div class="sh-definition-word">lis·ten·er / ˈlis(ə)nər / <em>noun</em>
-							</div>
-							<div class="sh-definition">
-								a seeker who chooses to help another seeker by intentionally creating a context for authentic interpersonal connection
-							</div>
-						</div>
 					</div>
 				</div>
 			</div>
@@ -297,15 +291,7 @@ page_title: Rethinking Rehab
 			<div class="content-wrap">
 				<div class="row clearfix common-height">
 
-					<div class="col-md-6 col-padding" style="background: url('images/connection-booster-def.jpg') center center no-repeat; background-size: cover;">
-						<div class="image-definition">
-							<div class="sh-definition-word">con·nec·tion boost·er / kəˈnekSH(ə)n / ˈbo͞ostər / <em>noun</em>
-							</div>
-							<div class="sh-definition">
-								any ritual, activity or practice that facilitates healing, personal growth, mindfulness, inner peace, and/or a sense of connectedness to self/other/nature
-							</div>
-						</div>
-					</div>
+					<div class="col-md-6 col-padding" style="background: url('images/connection-booster-def.jpg') center center no-repeat; background-size: cover;"></div>
 
 					<div class="col-md-6 center col-padding" style="background-color: #ffffff;">
 						<div>
@@ -318,6 +304,13 @@ page_title: Rethinking Rehab
 
 							<div class="center bottommargin">
 								<img src="images/owlLightbulb-250.png" width="120px" height="auto">
+							</div>
+
+							<div class="image-definition">
+								<div class="sh-definition-word">con·nec·tion boost·er / kəˈnekSH(ə)n / ˈbo͞ostər / <em>noun</em></div>
+								<div class="sh-definition">
+									any ritual, activity or practice that facilitates healing, personal growth, mindfulness, inner peace, and/or a sense of connectedness to self/other/nature
+								</div>
 							</div>
 						</div>
 					</div>
@@ -334,7 +327,7 @@ page_title: Rethinking Rehab
 						<span class="non-emphasized-header">don’t come in a pill</span>
 					</div>
 					<div class="row">
-						<div class="col-md-8 col-md-offset-2 col-sm-8 col-sm-offset-2 col-xs-12 col-xs-offset-2 text-center">
+						<div class="col-md-8 col-md-offset-2 col-sm-8 col-sm-offset-2 col-xs-12 text-center">
 							<p>
 								The right prescription might help you get started, but the journey to integrated health is a long road in which we need each other to help navigate. The truth is, the only ‘medicine’ that works for everyone is connection: meaningful and authentic connection with ourselves, with each other, and with our planet. 
 							</p>


### PR DESCRIPTION
This PR fixes #13 by including all of the style changes indicated in the issue.

# Line item changes requested in #13
## 1. Remove animation and re-style backgrounds
> Please get rid of the animation and post-it notes. I think it would be more visually appealing and less cumbersome if you just have A or B, static, and on slightly transparent red backgrounds. and then "As it turns out ... " with the tiny little underline thing, and C. None of the Above, on a slightly transparent green background

This item was pretty self explanatory and removed the animations in the CSS file.  I guessed on the exact colors and transparencies based on what I thought looked good, but I am certainly no designer, so happy to adjust if necessary.  Below is how that section now looks:

<img width="898" alt="screen shot 2017-10-09 at 10 23 14 pm" src="https://user-images.githubusercontent.com/2396774/31366733-a9ed33b8-ad40-11e7-8ecc-877f84abe790.png">

## 2. Move definitions overlays
> Please remove the definitions from being overlaid across the pictures and instead add them as smaller font, maybe in typewriter/dictionary font, below the owl(s) in each section.

I made an assumption that this ONLY meant "definitions" and not the quotes that are overlaid on the images because the quote sections don't have owl(s)?  Not sure if you would like to keep the quotes over the images or move them too?  

I also wasn't sure which font specifically to use, but I chose [Cousine](https://fonts.google.com/specimen/Cousine).

## 3. Mobile Optimizations
> Please note that the mobile optimization for this page may be tricky and require special attention.

There were several areas on this page that broke down responsively very poorly.  So, I also included some edits that make this page read much better across different devices/browser widths.  I think there is still much work to be done across the entire site with regards to responsiveness (which I may recommend a complete refactor the more I do some analysis), but this page's main content should be much better for the short term.  Below are a few before/after screen captures of where I concentrated on the responsiveness of this page:

![top](https://user-images.githubusercontent.com/2396774/31478292-6168913e-aedd-11e7-9dff-dd7956c37ce0.jpg)

![opiod](https://user-images.githubusercontent.com/2396774/31478307-79db69e4-aedd-11e7-906b-a5ab766f969d.jpg)

![imgs](https://user-images.githubusercontent.com/2396774/31478314-82f4c08e-aedd-11e7-890c-e9d5d96377b6.jpg)

![facilities](https://user-images.githubusercontent.com/2396774/31478321-8abf7106-aedd-11e7-8fa3-328eb93101c4.jpg)
