### PR TITLE
Content: Updating top nav & adding placeholders pages

### DIFF
--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -10,9 +10,15 @@
 									<li><a href="science-of-connection.html"><div>The Science of Connection</div></a></li>
 								</ul>
 							</li>
-							<li><a href="our-programs.html"><div>Our Programs</div></a></li>
-							<li><a href="get-involved.html"><div>Get Involved</div></a></li>
-							<li><a href="blog.html"><div>Stay Connected</div></a>
+							<li><a href="our-programs.html"><div>Heal</div></a>
+								<ul>
+									<li><a href="our-programs.html"><div>Our Programs</div></a></li>
+									<li><a href="guidance-for-detox.html"><div>Guidance for Detox</div></a></li>
+									<li><a href="seekconnection.html"><div>SeekConnection</div></a></li>
+								</ul>
+							</li>
+							<li><a href="get-involved.html"><div>Help</div></a></li>
+							<li><a href="blog.html"><div>Connect</div></a>
 								<ul>
 									<li><a href="blog.html"><div>Blog</div></a></li>
 									<!--<li><a href="gallery.html"><div>Gallery</div></a></li>-->

--- a/guidance-for-detox.html
+++ b/guidance-for-detox.html
@@ -1,0 +1,46 @@
+---
+page_title: Guidance for Detox
+---
+{% include header.html %}
+<body class="stretched">
+
+	<!-- Document Wrapper
+	============================================= -->
+	<div id="wrapper" class="clearfix">
+
+		<!-- Header
+		============================================= -->
+		<header id="header" class="dark">
+
+			<div id="header-wrap">
+
+				<div class="container clearfix">
+
+					<div id="primary-menu-trigger"><i class="icon-reorder"></i></div>
+
+					<!-- Logo
+					============================================= -->
+					<div id="logo">
+						<a href="index.html" class="standard-logo" data-dark-logo="images/logo-white.png"><img src="images/logo@2x.png" alt="SeekHealing Logo"></a>
+						<a href="index.html" class="retina-logo" data-dark-logo="images/logo-white.png"><img src="images/logo@2x.png" alt="SeekHealing Logo"></a>
+					</div><!-- #logo end -->
+
+					{% include nav.html %}
+				</div>
+
+			</div>
+
+		</header><!-- #header end -->
+
+		<section class="explanation-text-section">
+			<div class="section" >
+				<div class="container clearfix">
+					<div class="heading-block center">
+						<span class="non-emphasized-header">Coming Soon... </span>						
+					</div>
+
+				</div>
+			</div>
+		</section>
+
+{% include footer.html %}

--- a/seekconnection.html
+++ b/seekconnection.html
@@ -1,0 +1,46 @@
+---
+page_title: Guidance for Detox
+---
+{% include header.html %}
+<body class="stretched">
+
+	<!-- Document Wrapper
+	============================================= -->
+	<div id="wrapper" class="clearfix">
+
+		<!-- Header
+		============================================= -->
+		<header id="header" class="dark">
+
+			<div id="header-wrap">
+
+				<div class="container clearfix">
+
+					<div id="primary-menu-trigger"><i class="icon-reorder"></i></div>
+
+					<!-- Logo
+					============================================= -->
+					<div id="logo">
+						<a href="index.html" class="standard-logo" data-dark-logo="images/logo-white.png"><img src="images/logo@2x.png" alt="SeekHealing Logo"></a>
+						<a href="index.html" class="retina-logo" data-dark-logo="images/logo-white.png"><img src="images/logo@2x.png" alt="SeekHealing Logo"></a>
+					</div><!-- #logo end -->
+
+					{% include nav.html %}
+				</div>
+
+			</div>
+
+		</header><!-- #header end -->
+
+		<section class="explanation-text-section">
+			<div class="section" >
+				<div class="container clearfix">
+					<div class="heading-block center">
+						<span class="non-emphasized-header">Coming Soon... </span>						
+					</div>
+
+				</div>
+			</div>
+		</section>
+
+{% include footer.html %}


### PR DESCRIPTION
This pull request fixes #30.

The updated ask for this issue, as I understand it, was to update the top nav and 2 new placeholder pages to the site.

The top nav verbage was updated in the `_includes/nav.html` file and added 2 new placeholder, flat HTML pages to the root of the site.  One for "Guidance for Detox" and one for "SeekConnection".  Below is a screen cap of the new menu structure and an example of the "Coming Soon" placeholder pages:

<img width="1241" alt="screen shot 2017-10-14 at 10 55 58 pm" src="https://user-images.githubusercontent.com/2396774/31581216-ba3f85da-b133-11e7-9574-efb3c039135b.png">
