### PR TITLE
Content: Adding information packet & link

### DIFF
--- a/index.html
+++ b/index.html
@@ -166,6 +166,8 @@ page_title: Home
 					<div class="row">
 						<div class="col-md-8 col-md-offset-2 col-sm-8 col-sm-offset-2 col-xs-12 text-center">
 							<p>SeekHealing is a detox aftercare model that unlocks the neurochemical benefits of authentic connection experiences. This non-profit organization provides equal-opportunity programs that use principles of connection & community to facilitate sustainable healing after detox from opioid &amp; heroin addiction.</p>
+
+							<p><a href="downloads/SH Info Packet.pdf">For more information about SeekHealing</a></p>
 						</div>
 					</div>
 				</div>


### PR DESCRIPTION
This update fixes #43 by adding:
- the information packet to a `downloads` directory that can be used to house other downloadable content pdfs, docs, ppts, etc.
- a link to the pdf at the bottom of the home page per the issue that says, "For more information about SeekHealing".

Below screen cap is how it all looks:

<img width="880" alt="screen shot 2017-10-18 at 7 45 42 pm" src="https://user-images.githubusercontent.com/2396774/31747859-615dead0-b43d-11e7-803d-8b170662b441.png">
