### PR TITLE
Content: Creating help submenu & volunteer page

### DIFF
--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -17,7 +17,13 @@
 									<li><a href="seekconnection.html"><div>SeekConnection</div></a></li>
 								</ul>
 							</li>
-							<li><a href="get-involved.html"><div>Help</div></a></li>
+							<li><a href="get-involved.html"><div>Help</div></a>
+								<ul>
+									<li><a href="https://seekhealing.kindful.com" target="_blank"><div>Donate</div></a></li>
+									<li><a href="http://shop.seekhealing.org/" target="_blank"><div>Shop</div></a></li>
+									<li><a href="volunteer.html"><div>Volunteer</div></a></li>
+								</ul>
+							</li>
 							<li><a href="blog.html"><div>Connect</div></a>
 								<ul>
 									<li><a href="blog.html"><div>Blog</div></a></li>

--- a/volunteer.html
+++ b/volunteer.html
@@ -1,0 +1,60 @@
+---
+page_title: Volunteer
+---
+{% include header.html %}
+<body class="stretched">
+
+	<!-- Document Wrapper
+	============================================= -->
+	<div id="wrapper" class="clearfix">
+
+		<!-- Header
+		============================================= -->
+		<header id="header" class="dark">
+
+			<div id="header-wrap">
+
+				<div class="container clearfix">
+
+					<div id="primary-menu-trigger"><i class="icon-reorder"></i></div>
+
+					<!-- Logo
+					============================================= -->
+					<div id="logo">
+						<a href="index.html" class="standard-logo" data-dark-logo="images/logo-white.png"><img src="images/logo@2x.png" alt="SeekHealing Logo"></a>
+						<a href="index.html" class="retina-logo" data-dark-logo="images/logo-white.png"><img src="images/logo@2x.png" alt="SeekHealing Logo"></a>
+					</div><!-- #logo end -->
+
+					{% include nav.html %}
+				</div>
+
+			</div>
+
+		</header><!-- #header end -->
+		<section id="volunteer" class="explanation-text-section">
+			<div class="section" style="background-color: #fff;">
+				<div class="container clearfix">
+					<div class="heading-block center">
+						<span class="emphasized-header">Volunteer </span>
+					</div>
+					<div class="row">
+						<div class="col-xs-12 text-center">
+							<p>All of us can be seekers, searching for connection, for meaning, and for growth in our lives. All of us can support other seekers in their own journeys.</p>
+							<p>You can volunteer to help SeekHealing in its mission to facilitate the healing journey of seekers struggling with heroin or opioid addiction.</p>
+							<p>Whatever your background, wherever you are in live, reach out today to find out how you can help a fellow seeker through the SeekHealing project.</p>
+							<p><a href="mailto:info@seekhealing.org">info@seekhealing.org</a><p>
+						</div>
+					</div>
+
+				</div>
+			</div>
+		</section>
+
+		<!-- Content
+		============================================= -->
+		
+		
+
+		<!-- Footer
+		============================================= -->
+{% include footer.html %}


### PR DESCRIPTION
This update fixes #39 that calls for adding a submenu under the, now called, "help" top nav item.  One of the submenu items also required a new volunteer page be created with the same content from the get-involved page which you can see in below screen capture:

<img width="1176" alt="screen shot 2017-10-20 at 7 11 05 pm" src="https://user-images.githubusercontent.com/2396774/31844997-8338265a-b5ca-11e7-9b7d-9ee35aa042f0.png">
