### PR TITLE
Content: Adding They were here page

### DIFF
--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -29,6 +29,7 @@
 								<ul>
 									<li><a href="board-of-directors.html"><div>Board of Directors</div></a></li>
 									<!--<li><a href="legal-financial.html"><div>Legal & Financial Statements</div></a></li>-->
+									<li><a href="they-were-here.html"><div>They Were Here</div></a></li>
 									<li><a href="contact.html"><div>Contact</div></a></li>
 								</ul>
 							</li>

--- a/css/custom.css
+++ b/css/custom.css
@@ -620,6 +620,16 @@ a.button.button-plan-purple.button-3d:hover {
 .feature-box.fbox-plain .fbox-icon i {
 	color: #7f3472;
 }
+/**************************/
+/*****THEY WERE HERE***/
+/**************************/
+.remembered ul {
+	list-style-type: none;
+}
+.remembered span {
+	font-style: italic;
+	font-size: 12px;
+}
 /***********************/
 /*****MOBILE STYLES*****/
 /***********************/

--- a/they-were-here.html
+++ b/they-were-here.html
@@ -1,0 +1,52 @@
+---
+page_title: They Were Here
+---
+{% include header.html %}
+<body class="stretched">
+
+	<!-- Document Wrapper
+	============================================= -->
+	<div id="wrapper" class="clearfix">
+
+		<!-- Header
+		============================================= -->
+		<header id="header" class="dark">
+
+			<div id="header-wrap">
+
+				<div class="container clearfix">
+
+					<div id="primary-menu-trigger"><i class="icon-reorder"></i></div>
+
+					<!-- Logo
+					============================================= -->
+					<div id="logo">
+						<a href="index.html" class="standard-logo" data-dark-logo="images/logo-white.png"><img src="images/logo@2x.png" alt="SeekHealing Logo"></a>
+						<a href="index.html" class="retina-logo" data-dark-logo="images/logo-white.png"><img src="images/logo@2x.png" alt="SeekHealing Logo"></a>
+					</div><!-- #logo end -->
+
+					{% include nav.html %}
+				</div>
+
+			</div>
+
+		</header><!-- #header end -->
+
+		<section class="explanation-text-section">
+			<div class="section" >
+				<div class="container clearfix">
+					<div class="heading-block center">
+						<span class="non-emphasized-header">Memorial Wall</span>
+						<p>May the radiance of their memories light the way for all who seek healing.</p>
+					</div>
+
+					<div class="text-center remembered">
+						<ul>
+							<li>Artem Caravelli<br/>
+								- <span>remembered by Irene Lieberman</span></li>
+					</div>
+				</div>
+			</div>
+		</section>
+
+{% include footer.html %}


### PR DESCRIPTION
This update fixes #35  that calls for adding a "They Were Here" page under the "About Us" menu.

Below is a screen cap of how the new page is stubbed out to look:

<img width="1193" alt="screen shot 2017-10-21 at 5 34 07 pm" src="https://user-images.githubusercontent.com/2396774/31856059-44d4cfb4-b686-11e7-8708-5889893a5004.png">
