### PR TITLE
Bug: Fixing hidden menu nav item

### DIFF
--- a/css/custom.css
+++ b/css/custom.css
@@ -841,9 +841,6 @@ blockquote cite:before {
 	}	
 }
 @media(max-width: 1024px){
-	nav#primary-menu ul li:nth-child(5){
-		display: none;
-	}
 	.show-under-1024 {
 		display: block;
 	}


### PR DESCRIPTION
This PR fixes #55 which was a bug where the "About Us" navigational menu item was not being shown.

The solution for this problem was due to, what appears to be, a deliberately placed CSS rule to hide the specifically, 5th menu item on mobile.  I'm not sure the reason behind why such a CSS rule would exist, maybe the 5th menu item broke a previous design or something?

At any rate, I removed the CSS rule in this pull request so the "About Us" menu item will display normally like the other menu items.  Screenshot below with "About Us" submenu expanded:

<img width="394" alt="screen shot 2017-11-09 at 7 14 23 pm" src="https://user-images.githubusercontent.com/2396774/32636465-ead918ce-c582-11e7-9ab6-6067cce68c64.png">
