### PR TITLE
Content: Update main nav with "Remember" option

### DIFF
--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -31,11 +31,11 @@
 									<li><a href="upcoming-events.html"><div>Upcoming Events</div></a></li>
 								</ul>
 							</li>
+							<li><a href="they-were-here.html"><div>Remember</div></a></li>
 							<li><a href="about.html"><div>About Us</div></a>
 								<ul>
 									<li><a href="board-of-directors.html"><div>Board of Directors</div></a></li>
 									<li><a href="financials.html"><div>Financials</div></a></li>
-									<li><a href="they-were-here.html"><div>They Were Here</div></a></li>
 									<li><a href="contact.html"><div>Contact</div></a></li>
 								</ul>
 							</li>


### PR DESCRIPTION
This PR fixes #57 that moves the "They Were Here" navigation submenu currently located under "About Us" to it's own distinct nav item called "Remember".