### PR TITLE
Feature: Subscription form addition to home page

### DIFF
--- a/css/custom.css
+++ b/css/custom.css
@@ -7,6 +7,9 @@
 body {
 	color: #777;
 }
+form {
+  margin: 0;
+}
 p {
 	font-size: 16px;
 }
@@ -359,6 +362,37 @@ section.section-image-left, section.section-image-right{
 	top: -153px;
 	right: -465px;
 }
+/**************************/
+/***SUBSCRIBE STYLES*******/
+/**************************/
+.subscribe {
+  background-color: #333;
+  color: #CCC;
+  padding: 35px;
+}
+.subscribe .input-group {
+  width:50%;
+  margin:0 auto 10px;
+}
+.btn-subscribe {
+  margin: 0px;
+  background-color: #7f3472;
+  display: inline-block;
+  color: #fff;
+  border-color: #7f3472;
+  padding-left: 30px;
+  padding-right: 30px;
+  text-transform: uppercase;
+  font-weight: 800;
+  font-size: 14px;
+}
+.btn-subscribe:hover {
+  color: #7f3472;
+  background-color: #fff;
+}
+/**************************/
+/***END SUBSCRIBE STYLES***/
+/**************************/
 /**************************//**************************/
 /***END HOME PAGE STYLES***//***END HOME PAGE STYLES***/
 /**************************//**************************/
@@ -926,6 +960,9 @@ ul.resources {
 	.traditional-model {
 	  width: 100%;
 	}
+  .subscribe .input-group {
+    width: 70%;
+  }
 }
 @media(max-width: 768px){
 	#standardNarrative .sticky-note {
@@ -966,6 +1003,9 @@ ul.resources {
 	}
 }
 @media(max-width: 736px){
+  .subscribe .input-group {
+    width: 100%;
+  }
   #slider h1 {
     font-size: 34px;
   }

--- a/index.html
+++ b/index.html
@@ -105,6 +105,37 @@ page_title: Home
 							<p><a href="downloads/SH Info Packet.pdf">Click here to download a brochure for more information</a></p>
 						</div>
 					</div>
+				</div>
+			</div>
+		</section>
+
+		<section id="subscribe" class="subscribe">
+			<!-- Begin MailChimp Signup Form -->
+			<div id="mc_embed_signup">
+				<form action="https://seekhealing.us14.list-manage.com/subscribe/post?u=b5ccdb9ee0337d7a627a1c1a5&amp;id=800ac4eef4" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="validate text-center" target="_blank" novalidate="">
+    			<h3 for="mce-EMAIL" style="color: #fff;">Subscribe to our mailing list</h3>
+  				<div id="mc_embed_signup_scroll" class="text-center">
+
+						<!-- real people should not fill this in and expect good things - do not remove this or risk form bot signups-->
+						<div class="sr-only" aria-hidden="true">
+							<input type="text" name="b_b5ccdb9ee0337d7a627a1c1a5_800ac4eef4" tabindex="-1" value="">
+						</div>
+
+						<div class="input-group">
+    					<input type="email" value="" name="EMAIL" class="email form-control" id="mce-EMAIL" placeholder="email address" required="">
+    					<span class="input-group-btn">
+      					<input type="submit" class="btn btn-default btn-subscribe" value="Subscribe" name="subscribe" id="mc-embedded-subscribe">
+    					</span>
+  					</div><!-- /input-group -->
+
+  				</div>
+				</form>
+			</div><!--End mc_embed_signup-->
+		</section>
+
+		<section id="personalStories" class="explanation-text-section">
+			<div class="section">
+				<div class="container clearfix">
 
 					<div class="row">
 						<div class="col-xs-12">


### PR DESCRIPTION
This PR fixes and finalizes #58.

The outstanding item in #58 that haven't been addressed in prior pull requests was the task to add a MailChimp subscription form to the home page of the site below the brochure download link.  This PR accomplishes that last remaining item.

## Notes:
- This is the most basic implementation and only requires a user to input their email address.  If other fields are desired, please let me know.
-  Additionally, the most basic implementation will take the user to MailChimp after clicking the submit button.  If any other action is needed, we can adjust that, but it will take additional time obviously.
- Finally, wasn't sure if there was any design in mind for the overall look/feel of the subscription form, so I went with what I thought made the most sense and utilizing the header/footer background color since the form is in the middle of content to make it stick out a little more and tried to utilize some existing styling for the other form elements.  Obviously that is all adjustable if desired.  Screenshots below of desktop and mobile so you can get an idea of how it looks as well.

## Screenshots:
### Desktop
<img width="1431" alt="screen shot 2017-11-27 at 9 12 25 pm" src="https://user-images.githubusercontent.com/2396774/33299249-c121a48a-d3b8-11e7-8d61-0289e9744fba.png">

### Mobile
<img width="400" alt="screen shot 2017-11-27 at 9 11 43 pm" src="https://user-images.githubusercontent.com/2396774/33299251-c835799a-d3b8-11e7-99f9-afd4f09d822d.png">


 