### PR TITLE
Content: Fixing typo for addictions

### DIFF
--- a/rethinking-rehab.html
+++ b/rethinking-rehab.html
@@ -110,7 +110,7 @@ page_title: Rethinking Rehab
 									<strong>the opposite of addiction is not sobriety:</strong> 
 								</span>
 								<span class="non-emphasized-header">
-									rather, it is authentic connection and a deeply rooted sense of purpose & belonging.
+									rather, it is authentic connection and a deeply rooted sense of purpose &amp; belonging.
 								</span> 
 							</div>
 
@@ -211,7 +211,7 @@ page_title: Rethinking Rehab
 					<div class="row">
 						<div class="col-md-8 col-md-offset-2 col-sm-8 col-sm-offset-2 col-xs-12 text-center">
 							<p>
-								 Our <a href="project-plan.html">facilities & programs</a>  are intentionally designed to enhance an individual’s experience of connectedness, rather than diagnosing & treating specific problems.
+								 Our <a href="project-plan.html">facilities &amp; programs</a>  are intentionally designed to enhance an individual’s experience of connectedness, rather than diagnosing &amp; treating specific problems.
 							</p>
 							<p>
 								We believe that using the label <em>addict</em> facilitates socially-acceptable shaming. Stigmatizing people as addicts and creating non-addict/addict relationships in therapeutic settings often worsens the roots causes of addiction: isolation and disconnectedness.
@@ -249,7 +249,7 @@ page_title: Rethinking Rehab
 							<div class="image-definition">
 								<div class="sh-definition-word">seek &middot; er / ˈsēkər / <em>noun</em></div>
 								<div class="sh-definition">
-									a person who is actively seeking to become a better human by overcoming unhealthy behaviors, addications, and/or compulsions and their associated emotional triggers.
+									a person who is actively seeking to become a better human by overcoming unhealthy behaviors, addictions, and/or compulsions and their associated emotional triggers.
 								</div>
 							</div>
 						</div>
@@ -267,7 +267,7 @@ page_title: Rethinking Rehab
 								<span class="emphasized-header">accept the challenge </span>
 								<span class="non-emphasized-header">and to seek healing, we will each also have the opportunity to </span>
 								<span  class="emphasized-header">become a listener </span> 
-								<span class="non-emphasized-header">& support our fellow seekers.</span>
+								<span class="non-emphasized-header">&amp; support our fellow seekers.</span>
 							</div>
 
 							<div class="center bottommargin">
@@ -298,7 +298,7 @@ page_title: Rethinking Rehab
 							<div class="heading-block nobottomborder">
 								<span class="non-emphasized-header">As we grow, we learn how to 	</span>
 								<span class="emphasized-header">continuously transition </span>
-								<span class="non-emphasized-header">between these roles with humility and grace. Usually, with the help & community support of a </span>
+								<span class="non-emphasized-header">between these roles with humility and grace. Usually, with the help &amp; community support of a </span>
 								<span  class="emphasized-header">particular booster</span> 
 							</div>
 


### PR DESCRIPTION
This PR fixes #67 for a typo on the rethinking rehab page.  In addition to the typo, I also found a couple other instances where HTML entities weren't used where they probably should be.