### PR TITLE
Feature: Changes to top navigation

### DIFF
--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -3,13 +3,7 @@
 					<nav id="primary-menu">
 
 						<ul>
-							<li><a href="learn.html"><div>Learn</div></a>
-								<ul>
-									<li><a href="why-we-care.html"><div>The Heroin Epidemic</div></a></li>
-									<li><a href="rethinking-rehab.html"><div>Rethinking Rehab</div></a></li>
-									<li><a href="science-of-connection.html"><div>The Science of Connection</div></a></li>
-								</ul>
-							</li>
+							<li><a href="learn.html"><div>Learn</div></a></li>
 							<li><a href="our-programs.html"><div>Heal</div></a>
 								<ul>
 									<li><a href="our-programs.html"><div>Our Programs</div></a></li>
@@ -17,7 +11,7 @@
 									<li><a href="seekconnection.html"><div>SeekConnection</div></a></li>
 								</ul>
 							</li>
-							<li><a href="get-involved.html"><div>Help</div></a>
+							<li><a href="volunteer.html"><div>Help</div></a>
 								<ul>
 									<li><a href="https://seekhealing.kindful.com" target="_blank"><div>Donate</div></a></li>
 									<li><a href="http://shop.seekhealing.org/" target="_blank"><div>Shop</div></a></li>
@@ -33,13 +27,7 @@
 								</ul>
 							</li>
 							<li><a href="they-were-here.html"><div>Remember</div></a></li>
-							<li><a href="about.html"><div>About Us</div></a>
-								<ul>
-									<li><a href="board-of-directors.html"><div>Board of Directors</div></a></li>
-									<li><a href="financials.html"><div>Financials</div></a></li>
-									<li><a href="contact.html"><div>Contact</div></a></li>
-								</ul>
-							</li>
+							<li><a href="about.html"><div>About Us</div></a></li>
 							<!-- <li><a href="get-help-now.html" class="button button-border button-rounded button-sh-purple">I need help now</a></li> -->
 						</ul>
 					</nav><!-- #primary-menu end -->

--- a/about.html
+++ b/about.html
@@ -41,7 +41,7 @@ page_title: About Us
 							Us
 						</span>						
 					</div>
-					<div class="col-md-4 col-md-offset-2 col-sm-4 col-sm-offset-2 col-xs-4 col-xs-offset-2">
+					<div class="col_one_third">
 						<div class="feature-box fbox-center fbox-outline fbox-effect nobottomborder">
 							<div class="fbox-icon">
 								<a href="board-of-directors.html"><i id="boardDirectors"></i></a>
@@ -50,16 +50,16 @@ page_title: About Us
 						</div>
 					</div>
 
-					<!--<div class="col_one_third">
+					<div class="col_one_third">
 						<div class="feature-box fbox-center fbox-outline fbox-effect nobottomborder">
 							<div class="fbox-icon">
-								<a href="#"><i id="projectPlan"></i></a>
+								<a href="/financials.html"><i id="donateImg"></i></a>
 							</div>
-							<h3>Legal & Financial Statements<span class="subtitle">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla sagittis.</span></h3>
+							<h3>Financials<span class="subtitle">Take a look at our financials and documentation for your tax deductions</span></h3>
 						</div>
-					</div>-->
+					</div>
 
-					<div class="col-md-4 col-sm-4 col-xs-4">
+					<div class="col_one_third col_last">
 						<div class="feature-box fbox-center fbox-outline fbox-effect nobottomborder">
 							<div class="fbox-icon">
 								<a href="contact.html"><i id="contactUs"></i></a>


### PR DESCRIPTION
This issue fixes #76 that detailed some top navigation changes.

Everything is pretty straight forward here, but there wasn't any "content" identified for the new financials icon on the about page.  I used the following copy as placeholder: "Take a look at our financials and documentation for your tax deductions".

Below is a screen capture of the new about page with the financial icon that I choose which was actually already being used on the get-involved page.

### New About page 

![screencapture-localhost-4000-about-html-1516482524682](https://user-images.githubusercontent.com/2396774/35188031-3a970efa-fdfc-11e7-8ef5-55ae38ca0702.png)
