### PR TITLE
Content: Removing "Program Methodology" from the "Heal" top nav

### DIFF
--- a/_data/footer.yaml
+++ b/_data/footer.yaml
@@ -3,7 +3,7 @@ nav:
   - title: Learn
     url: /learn/
   - title: Our Programs
-    url: /our-programs/
+    url: /asheville-pilot-program/
   - title: Get Involved
     url: /get-involved/
   - title: Blog

--- a/_data/header.yaml
+++ b/_data/header.yaml
@@ -4,8 +4,6 @@ nav:
   - title: Learn
     url: /learn/
   - submenu:
-      - title: Program Methodology
-        url: /our-programs/
       - title: Listening Training
         url: /listening-training/
       - title: Asheville Pilot Program
@@ -13,7 +11,7 @@ nav:
       - title: Asheville Connection Agent Partners
         url: /asheville-connection-agent-partners/
     title: Heal
-    url: /our-programs/
+    url: /asheville-pilot-program/
   - submenu:
       - target: _blank
         title: Donate


### PR DESCRIPTION
This PR address #88 which is to hide the "Program Methodology" navigational item from the "Heal" top nav.

Just an FYI, the "Heal" top nav also links to the `/our-programs/` page and there is also a footer item titled "Our-Programs" that links to `/our-programs/`.  Not sure if it is desired to change the "Heal" link and remove the footer link as well?  

For now, just removed the top nav item per the issue.

