### PR TITLE
Content: Adding Rachel's TED talk video to science-of-connection page

### DIFF
--- a/_pages/science-of-connection.md
+++ b/_pages/science-of-connection.md
@@ -2,6 +2,8 @@
 layout: page
 title: Science of Connection
 sections:
+  - type: "single"
+    title: "rachel-ted-talk"
   - type: "article"
     title: "science-connection"
   - type: "double"

--- a/_sections/single/rachel-ted-talk.md
+++ b/_sections/single/rachel-ted-talk.md
@@ -1,0 +1,11 @@
+---
+type: single
+title: rachel-ted-talk
+col-width: "wide"
+---
+
+<div class="medium max-vid-width">
+  <div class="embed-responsive embed-responsive-16by9">
+    <iframe src="https://www.youtube.com/embed/m7fGPGj2kaY" frameborder="0" allowfullscreen=""></iframe>
+  </div>
+</div>


### PR DESCRIPTION
This PR addresses #93 which was to add Rachel's TED talk video to the top of the science-of-connection page.

In order to accomplish this, we simply added a new content section to the science-of-connection page and added the youtube embed code.

Below is a screen capture of viewing it on a desktop browser:

<img width="951" alt="screen shot 2018-06-23 at 2 42 47 pm" src="https://user-images.githubusercontent.com/2396774/41812588-c59b18aa-76f3-11e8-86d9-d24e583ee337.png">
