### PR TITLE
BUG: Fixing broken links

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -29,8 +29,6 @@ permalink: "/blog/:title/"
 sass:
   sass_dir: _sass
   style: compressed
-include:
-- _pages
 exclude:
 - .gitignore
 - README.md

--- a/_data/asheville-pilot-program.yaml
+++ b/_data/asheville-pilot-program.yaml
@@ -47,7 +47,7 @@ apply-links:
     url: "https://bit.ly/listenAVL"
   - title: '<span class="bold">Become a <span class="green">Connection Agent</span> for your business or non-profit.</span>'
     btn-txt: "bit.ly/connectAVL"
-    url: "bit.ly/connectAVL"
+    url: "https://bit.ly/connectAVL"
 subtext: "SeekHealing is a 501(c)3 non-profit. All program participation is free of charge. Donations for listener training and connection agent contracts are suggested, but not required."
 partner-text: "Click here to check out our local Connection Agent partners in Asheville"
 partner-link: "/asheville-connection-agent-partners/"


### PR DESCRIPTION
This issue is an initial fix for actual bugs found in analysis of #106.  The 2 code fixes included with this fix:

1.  removes the `_pages` directory from being built out so hopefully users would never navigate to an `_pages` directory as was observed in the report shared in #106.

2. fixes a malformed URL on the /our-programs/ page. 