### PR TITLE
Bug: Fixing button focus style & safari 3 column layout

### DIFF
--- a/_sass/base/_base.scss
+++ b/_sass/base/_base.scss
@@ -88,3 +88,8 @@ blockquote {
 form {
   margin: 0;
 }
+
+// Bootstrap iOS fix
+.row.display-flex:after, .row.display-flex:before {
+  display: none;
+}

--- a/_sass/components/_buttons.scss
+++ b/_sass/components/_buttons.scss
@@ -21,7 +21,7 @@
   text-decoration: none;
   border-radius: 3px;
 
-  &:hover {
+  &:hover, &:focus {
     background-color: #5D4157;
     opacity: 0.9;
     color: #FFF;


### PR DESCRIPTION
This PR contains 2 fixes that were found will investigating #107.  I wasn't able to reproduce the issues exactly described in #107, but I the below 2 bugs were found and are fixed with this update:

1. The first issue was identified with the "focus" state of the purple buttons enabled, so one of the included style fixes makes the focus state the same styling as the hover state.

2. The second fix was identified only in Safari browsers and is a known bootstrap bug for multi column flexible layouts.

## Screenshots

### Before (notice the mis-aligned 3-col layout with the "Become a listener" button with focus")
<img width="1208" alt="screen shot 2018-06-30 at 8 11 12 pm" src="https://user-images.githubusercontent.com/2396774/42129982-dc47a1ea-7ca2-11e8-8f92-f9c5c4a2b476.png">


### After (notice the fixed column and button styling)
<img width="1190" alt="screen shot 2018-06-30 at 8 11 49 pm" src="https://user-images.githubusercontent.com/2396774/42129986-ff7317bc-7ca2-11e8-8f81-b4073118a352.png">

