### PR TITLE
CONTENT: Changing order of Asheville Pilot Program CTAs

### DIFF
--- a/_includes/sections/double.html
+++ b/_includes/sections/double.html
@@ -22,7 +22,7 @@
       </div>
       <div class="row display-flex ">
 
-        {% assign cols = site.sections |where:"type","double-col" |where:"col-names",double.col-names |order: "order" %}
+        {% assign cols = site.sections |where:"type","double-col" |where:"col-names",double.col-names |sort: "order" %}
 
         {% for col in cols %}
 

--- a/_includes/sections/triple.html
+++ b/_includes/sections/triple.html
@@ -22,7 +22,7 @@
       </div>
       <div class="row display-flex ">
 
-        {% assign cols = site.sections |where:"type","triple-col" |where:"col-names",triple.col-names |order: "order" %}
+        {% assign cols = site.sections |where:"type","triple-col" |where:"col-names",triple.col-names |sort: "order" %}
 
         {% for col in cols %}
 

--- a/_sections/triple-columns/triple-col-pilot-ctas-2.md
+++ b/_sections/triple-columns/triple-col-pilot-ctas-2.md
@@ -1,7 +1,7 @@
 ---
 type: triple-col
 col-names: "pilot-ctas-parts"
-order: 2
+order: 3
 class: button-group
 ---
 

--- a/_sections/triple-columns/triple-col-pilot-ctas-3.md
+++ b/_sections/triple-columns/triple-col-pilot-ctas-3.md
@@ -1,7 +1,7 @@
 ---
 type: triple-col
 col-names: "pilot-ctas-parts"
-order: 3
+order: 2
 class: button-group
 ---
 


### PR DESCRIPTION
This update fixes #119 that changes the order of the CTA buttons for the Asheville Pilot Program on the home page.  This should've simply been adjusting the `order` field on the content block's yaml, but I also saw there was a small bug in the layouts for the double and triple content blocks incorrectly using `order` as the liquid filter, but it should actually be `sort` so I had to update that as well.