### PR TITLE
Content: Changing listening training page buttons

### DIFF
--- a/_sections/single/apply.md
+++ b/_sections/single/apply.md
@@ -6,7 +6,4 @@ padding: no-top-padding
 
 <hr>
 
-[Apply Now](http://bit.ly/seeklistening){:class="button button-purple" target="_new"}
-
-Form takes about 20min. Due to restrictions in Google Forms, you can't save and come back, so make sure you're ready to start when you hit the button!
-{:class="italic size-14"}
+[Sign Up Now](http://bit.ly/listenAVL){:class="button button-purple" target="_new"}

--- a/_sections/single/listening-training-authetic-connection.md
+++ b/_sections/single/listening-training-authetic-connection.md
@@ -19,10 +19,7 @@ Volunteer and receive focused training in
 to help someone heal from an addiction crisis and to challenge your own emotional growth.
 {:class="italic-purple"}
 
-[Apply Now](http://bit.ly/seeklistening){:class="button button-purple" target="_new"}
-
-Form takes about 20min. Due to restrictions in Google Forms, you can't save and come back, so make sure you're ready to start when you hit the button!
-{:class="italic size-14"}
+[Sign Up Now](http://bit.ly/listenAVL){:class="button button-purple" target="_new"}
 
 <hr>
 

--- a/_sections/single/listening-training-training.md
+++ b/_sections/single/listening-training-training.md
@@ -21,6 +21,6 @@ col-width: thin
 - safety training in how to manage and respond to suicidal ideation
 - role-play training & practice
 
-[LEARN MORE AT AN INFO SESSION](https://www.eventbrite.com/e/seekhealing-info-session-tickets-44272326721){:class="button button-purple" target="_new"}
+[Sign Up Now](http://bit.ly/listenAVL){:class="button button-purple" target="_new"}
 
 ![Owl Friends](/assets/images/owlFriends.png){:max-width="560px" class="img-responsive"}


### PR DESCRIPTION
This PR fixes #123 that calls for changing the links & text for the listening training button as well as removing the italicized text underneath 2 of the buttons.

Screenshot of content changes:
![screencapture-localhost-4000-listening-training-2018-07-13-20_07_47](https://user-images.githubusercontent.com/2396774/42718615-7dcdbeb6-86d8-11e8-8755-11cd2394f720.png)
