### PR TITLE
Feature: Adding event expiration functionality

### DIFF
--- a/_includes/sections/events.html
+++ b/_includes/sections/events.html
@@ -20,21 +20,23 @@
 <section>
   <div class="section{% if include.title == "upcoming" %} white{% endif %}">
     <div class="container clearfix events">
-      <div class="row display-flex">
+      <div class="row display-flex {% if include.title == "upcoming" %}upcoming-events{% else %}past-events{% endif %}">
 
         <div class="normal-header">
           <h1>
-            {% if include.title == "upcoming" %} 
+            {% if include.title == "upcoming" %}
               {{ events_content.events-upcoming-text }}
+              {% assign event_class = "col-md-12 bottommargin expiration-date" %}
             {% else %}
               {{ events_content.events-past-text }}
+              {% assign event_class = "col-md-12 bottommargin" %}
             {% endif %}
           </h1>
         </div>
 
         {% for event in events %}
         
-          <div class="col-md-12 bottommargin">
+          <div class="{{ event_class }}"{% if include.title == "upcoming" %} data-limit="{{ event.date }}"{% endif %}>
             <div class="clearfix">
               <div class="event-image">
                 <img src="{{ site.baseurl }}{{ event.image }}" alt="Event">
@@ -50,7 +52,7 @@
                   {{ event.content | markdownify }}
 
                   {% if event.ticket-btn %}
-                    <p><a href="{{ event.ticket-url }}" target="_blank" class="button button-purple">{{ event.ticket-btn }}</a></p>
+                    <p><a href="{{ event.ticket-url }}" target="_blank" class="button button-purple rsvp">{{ event.ticket-btn }}</a></p>
                   {% endif %}
 
                 </div>

--- a/assets/js/functions.js
+++ b/assets/js/functions.js
@@ -2110,3 +2110,16 @@ var SEMICOLON = SEMICOLON || {};
 	$window.on( 'resize', SEMICOLON.documentOnResize.init );
 
 })(jQuery);
+
+// On Events page - moves expired events to the "past events" section
+$(function() {
+  var currentDate = Date.now();
+  $(".expiration-date").each(function() {
+    var specifiedDateLimit = $(this).data('limit');
+    var date = Date.parse(specifiedDateLimit);
+    if(!isNaN(date) && currentDate - date > 0) {
+      $(".past-events>.normal-header").after(this);
+      $( this ).find(".rsvp").hide();
+    }
+  });
+});


### PR DESCRIPTION
This PR adds the ability for upcoming events to expire automatically and be moved to the "Past Events" section on the Events page.

In order to accomplish this task, I added a simple javascript snippet that will check the date on each "Upcoming Event" and compare it to today's date on a user's device.  If the event's date has passed, then that event will be moved to the top of the "Past Events" section on the Events page and hide any "RSVP" call to action buttons for the event.