### PR TITLE
Content: Adding donation link to memorial page

### DIFF
--- a/_pages/they-were-here.md
+++ b/_pages/they-were-here.md
@@ -10,4 +10,7 @@ sections:
 {: class="no-bot-border"}
 
 May the radiance of their memories light the way for all who seek healing.
+<br>
+[Click here to memorialize a seeker's name on this wall and/or make a donation in their name](https://seekhealing.kindful.com/){: target="_blank" class="size-14 italic"}.
 {: class="subnav"}
+


### PR DESCRIPTION
This update addresses #134 which is to add a new header subtext to the memorial page that is also a link.

I wasn't sure where the link should go, but I assumed it should go to the donation page?  So, I made it go there and open in a new tab.  If that isn't the correct page to link to please let me know and I can update the URL.

Below is a screenshot of how the subnav link looks:

<img width="1228" alt="screen shot 2018-08-05 at 10 14 44 am" src="https://user-images.githubusercontent.com/2396774/43686738-c0850e7c-9898-11e8-8a8c-e8d710b340de.png">
