### PR TITLE
Removing "A Spark was Lit" Link

### DIFF
--- a/_sections/triple-columns/science-connection-ctas-parts-2.md
+++ b/_sections/triple-columns/science-connection-ctas-parts-2.md
@@ -1,8 +1,0 @@
----
-type: triple-col
-col-names: "science-connection-ctas-parts"
-order: 2
-class: button-group
----
-
-[A Spark Was Lit](/a-spark-was-lit/){:class="button button-purple"}


### PR DESCRIPTION
This PR is the first step which is critical for the short term to remove the "A Spark was Lit" link from the science of connection page.