### PR TITLE
SEO Fixes

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -14,12 +14,20 @@
   <meta http-equiv="content-type" content="text/html; charset=utf-8">
   <meta name="author" content="SeekHealing">
 
-  {% if page.keywords %}
-  <meta name="keywords" content="{{ page.keywords }}" >
-  {% endif %}
-
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>{% if page.page_title %}{{ page.page_title }} | {{ site.title }}{% else %}{{ site.title }}{% endif %}</title>
+
+  {% if page.sitemap == false %}
+    <meta name="robots" content="noindex">
+  {% endif %}
+
+  {% if page.keywords %}
+    <meta name="keywords" content="{{ page.keywords }}" >
+  {% endif %}
+
+  {% if page.description %}
+    <meta name="Description" content="{{ page.description }}">
+  {% endif %}
   
   <!-- Favicon -->
   <link rel="apple-touch-icon" sizes="180x180" href="{{ site.baseurl }}/assets/images/favicons/apple-touch-icon.png">

--- a/_pages/index.md
+++ b/_pages/index.md
@@ -2,6 +2,7 @@
 layout: page
 title: Home
 permalink: /
+description: "SeekHealing is a 501(c)3 non-profit serving people at risk for overdose. We provide free support services to anyone at any stage in the addiction healing process."
 transparent-header: true
 sections:
   - type: "hero"

--- a/_pages/our-programs.md
+++ b/_pages/our-programs.md
@@ -1,6 +1,7 @@
 ---
 layout: page
 title: Our Programs
+sitemap: false
 sections:
   - type: "single"
     title: "program-methodology"


### PR DESCRIPTION
Fixes #190.

This PR attempts to resolve the SEO adjustments requested in #190.

### What was done
- I believe that the "SeekHealing Programs" (`/our-programs`) page is showing up because it is still showing up in the [sitemap](https://seekhealing.org/sitemap.xml).  Adding `sitemap: false` will remove this page from being included in the sitemap and hopefully then removing it from search results.
- As an added layer of confidence to remove the "SeekHealing Programs" page (and future pages if needed...) from search results, I added a "noindex" meta tag that should also let search engines know we don't want those pages indexed.  That meta tag will be inserted on the page also based on the `sitemap: false` yml metadata.
- The main blurb is a little less direct on what search results will show as different engines use different criteria on what to show there.  I think if we add a "Description" meta tag to the home page, however, with the preferred blurb this should give us more control on what is shown there.  Not to mention having meta Description tags helps improve SEO overall.  We should probably add content for this on other pages as well if desired.  Also, please note, performing a search on "seekhealing" or "seek healing" in Google appears to now have the correct blurb as well, so it may have just taken Google a bit to re-crawl the site?
<img width="875" alt="screen shot 2019-01-26 at 11 19 03 am" src="https://user-images.githubusercontent.com/2396774/51789916-58152780-215c-11e9-825d-9c73d61bf9eb.png">

### Suggestion for more SEO improvements
I will send a separate note as well, but I also believe it would be good to sign up for a Google Webmaster account where we can request re-crawls of the site when desired and determine other improvements for SEO.
