### PR TITLE
Bug: Google calendar mobile/responsive fixes

### DIFF
--- a/_sections/single/calendar.md
+++ b/_sections/single/calendar.md
@@ -10,6 +10,10 @@ col-width: "wide"
 SeekHealing’s first non-residential program to treat addiction disease at the community level is currently in operation in Asheville, NC.
 {: class="subnav"}
 
-<div class="embed-responsive embed-responsive-16by9">
-<iframe src="https://calendar.google.com/calendar/embed?title=SeekHealing%20Community%20Events&amp;height=600&amp;wkst=1&amp;bgcolor=%23F9F9F9&amp;src=seekhealing.org_hbmn5j5moufbptnfi0mfgeepas%40group.calendar.google.com&amp;color=%23853104&amp;ctz=America%2FNew_York" style="border-width:0" width="800" height="600" frameborder="0" scrolling="no"></iframe>
+<div class="embed-responsive embed-responsive-16by9 hidden-xs">
+  <iframe src="https://calendar.google.com/calendar/embed?showCalendars=0&amp;title=SeekHealing%20Community%20Events&amp;height=600&amp;wkst=1&amp;bgcolor=%23F9F9F9&amp;src=seekhealing.org_hbmn5j5moufbptnfi0mfgeepas%40group.calendar.google.com&amp;color=%23853104&amp;ctz=America%2FNew_York" style="border-width:0" width="800" height="600" frameborder="0" scrolling="no" class="embed-responsive-item"></iframe>
+</div>
+
+<div class="visible-xs-block">
+  <iframe src="https://calendar.google.com/calendar/embed?title=SeekHealing%20Community%20Events&amp;showTabs=0&amp;showCalendars=0&amp;showTz=0&amp;mode=AGENDA&amp;height=800&amp;wkst=1&amp;bgcolor=%23F9F9F9&amp;src=seekhealing.org_hbmn5j5moufbptnfi0mfgeepas%40group.calendar.google.com&amp;color=%23B1440E&amp;ctz=America%2FNew_York" style="border-width:0" width="320" height="500" frameborder="0" scrolling="no"></iframe>
 </div>


### PR DESCRIPTION
This PR addresses the issue brought up in this slack conversation: https://seekhealing.slack.com/archives/CE76SU751/p1552152543001900

Unfortunately, I don't think there is 100% optimal fix for this solution with the Google Calendar embed functionality.  There are 2 better options for fixing this issue in my opinion however.  I am detailing both options below, but this PR is for the implementation of option number 2 that I think is better from a usability perspective and what I would recommend for my own site for this.  **_BOTH options do force an "agenda" view of the calendar in mobile screen sizes to maximize the calendar's usability.  Both options also address the immediate concern of being able to see events and open them though._** 

Additionally, if we wanted to use javascript instead of a Google calender iframe embed, we would have more options for addressing this as well.  But because this is an iframe of Google's calendar directly, we are a bit limited for options...

## Option 1
The first option would be to set the width of the iframe to be more responsive to the actual screen width, however, the downside to this option is that when clicking on events, on smaller screens, some of the details would be cut off which could be confusing for some users.  Screenshots of this below:

**Notice the event details being cut off on smaller screens:**
![IMG_0986](https://user-images.githubusercontent.com/2396774/54088780-e3770080-4337-11e9-88f6-421915d16ab0.PNG)

**Notice when viewing in landscape mode or wider mobile screens, the width of the calendar adjusts appropriately:**
![IMG_0987](https://user-images.githubusercontent.com/2396774/54088781-e671f100-4337-11e9-97b3-b7c180299226.PNG)


## Option 2
This option sets a fixed iframe width of 320px so it will force all of the content in the iframe to respect that width instead of option 1 that has a `width: 100%` to make better use of the screen's real estate.  The advantage of this option is the calendar details will not be cut off on smaller screens.  The downside is in wider mobile views, the calendar looks thin and doesn't automatically adjust to the full size of the screen.

**Notice that in larger mobile screens or landscape mode the calendar's width does not adjust automatically:**
![IMG_0985](https://user-images.githubusercontent.com/2396774/54088811-4a94b500-4338-11e9-802e-42b339e5b8c8.PNG)

**Notice however in the below screen shots that the event details do not ever get chopped off.  Longer event titles do, but in either option that happens.**
![IMG_0983](https://user-images.githubusercontent.com/2396774/54088809-4a94b500-4338-11e9-8fd2-748d8561b32e.PNG)
![IMG_0984](https://user-images.githubusercontent.com/2396774/54088810-4a94b500-4338-11e9-9de8-ef46f8b76292.PNG)
