### PR TITLE
Bug: Fixing duplicate testimonial text & style tweak for homepage

### DIFF
--- a/_sass/base/_base.scss
+++ b/_sass/base/_base.scss
@@ -66,7 +66,7 @@ blockquote {
     content: "\201C";
     font-size: 80px;
     position: absolute;
-    left: -20px;
+    left: -30px;
     top: -20px;
     font-family: Georgia, serif;
     font-size: 85px;

--- a/_sections/double-columns/travis-test-parts-2.md
+++ b/_sections/double-columns/travis-test-parts-2.md
@@ -4,5 +4,5 @@ col-names: "travis-test-parts"
 order: 2
 ---
 
-> I have attended rehab nine times. All the months I spent in rehab, everything I learned, does not compare with how valuable one weekend with Seekhealing was for me. It was truly an enlightening experience, and one I would highly recommend to others. Addiction caused me tremendous pain, and made me desperate for answers. SeekHealing has the simple, beautiful answer: human connection.
-> <cite>Farrell G.<br/>SeekHealing participant and former heroin user</cite>
+> Before SeekHealing, I lived my life in the shadows. I kept different parts of myself hidden from everyone in my life: I was a different person at work than I was with my family, than with my girlfriend, than with my drug dealer. Now, I live my life in the light. I'm living the life I want to live, and I'm being honest with the people around me about who I am, about what I do and don't want to do. It's because I have people to talk to about what's really going on, people who care about me and who will listen to me and not judge me for which chemicals I choose to use or not use.
+> <cite>Travis P.<br/>SeekHealing participant and former heroin user</cite>


### PR DESCRIPTION
This PR fixes a mistake introduced in #264 that duplicated 1 testimonial text twice and omitted one during the restructuring of that content on the home page.  In addition, this also includes a very minor style tweak.

This is for the following Slack conversation:
https://seekhealing.slack.com/archives/CE76SU751/p1560970988000800