### PR TITLE
July 2019 Updates: Learn page

### DIFF
--- a/_includes/sections/subnav.html
+++ b/_includes/sections/subnav.html
@@ -22,7 +22,7 @@
 
 <section>
   <div class="section" >
-    <div class="container clearfix text-center {% if include.title == 'Learn' %}subnav-header{% else %}normal-header{% endif %}">
+    <div class="container clearfix text-center normal-header">
 
       {{ page.content | markdownify }}
 

--- a/_pages/learn.md
+++ b/_pages/learn.md
@@ -11,7 +11,3 @@ sections:
 ---
 
 # <span class="emphasized-header">Science, Stats, and Research</span>
-{: class="no-bot-border"}
-
-You can’t heal in the same environment where you got sick.
-{: class="subnav"}

--- a/_sections/subnav/additional-resources.md
+++ b/_sections/subnav/additional-resources.md
@@ -4,7 +4,7 @@ title: additional-resources
 nav: Learn
 image: /assets/images/point-click.png
 link: "/additional-resources/"
-order: 4
+order: 5
 ---
 
 ## Additional Resources

--- a/_sections/subnav/harm-reduction.md
+++ b/_sections/subnav/harm-reduction.md
@@ -4,7 +4,7 @@ title: harm-reduction
 nav: Learn
 image: /assets/images/subnav-harm-reduction.png
 link: "/harm-reduction/"
-order: 5
+order: 4
 ---
 
 ## Harm Reduction


### PR DESCRIPTION
This PR completes the edits requested in the "July 2019 Cleanup Edits" document for the Learn(/learn/) page that include the following:

1. Please change the order of the buttons and make the Additional Resources icon the last one (after Harm Reduction)
2. Please remove “You can’t heal in the same environment where you got sick” (no replacement)
