### PR TITLE
July 2019 Updates: Listening Training page

### DIFF
--- a/_sections/single/listening-training-authetic-connection.md
+++ b/_sections/single/listening-training-authetic-connection.md
@@ -35,7 +35,7 @@ Note: Listening Training hours may count towards your Peer Support Specialist qu
 
 By completing this training, you'll become part of a radically different addiction treatment program in Buncombe County, NC. The disease of addiction shows up in individuals because it is first a disease of the community: a problem with how individuals within a group relate with one another. SeekHealing "treats" addiction disease at the community level.
 
-The training is a 16-hour course spanning two days (one day on each of two weekends) and covers techniques on how to offer listening and peer-based support to someone healing from opioid addiction. It will also teach you how to better listen to yourself and identify your own needs, whether you struggle with substance use or some other type of addiction.
+The training takes place over the course of a 6-week series or 2-day weekend retreat, and covers techniques on how to listen supportively to someone healing from opioid addiction (which also involves listening to yourself and learning how to set compassionate boundaries).
 
 After the training, you’ll be paired with someone else in the SeekHealing community in order to practice the art of human connection on a weekly basis. The subsequent [program](/heal/) will accelerate both of your healing & growth and you'll also have access to all kinds of awesome, donation-based groups, meetings and activities to explore with other people in the community.
 

--- a/_sections/single/listening-training-intro.md
+++ b/_sections/single/listening-training-intro.md
@@ -12,7 +12,9 @@ padding: no-bot-padding
 Learn how to better listen to yourself and others.
 {: class="subnav"}
 
-Join us for 16 hours of professional training in authentic human connection and peer-based addiction support. It's a one-of-a-kind opportunity to dig deeper into your own personal growth &amp; healing journey while lifting others up along the way.
+Practical training in active listening: the foundation for more meaningful connection with others. This course teaches you how to better listen to others, and yourself. It's a one-of-a-kind opportunity to dig deeper into your own personal growth & healing journey while lifting others up along the way. 
+
+Offered as a 6-week series (email [megan@seekhealing.org](mailto:megan@seekhealing.org) for next sign-up date) or weekend retreat ([click here](/upcoming-events/) to see when the next one is).
 
 Listening Training is provided free of cost by SeekHealing, a 501(c)3 nonprofit. The program is entirely donation based. A donation is not required but greatly appreciated.
 {:class="italic size-14"}


### PR DESCRIPTION
This PR completes the edits requested in the "July 2019 Cleanup Edits" document for the Listening Training(/listening-training/) page that include the following:

1. change 

> Join us for 16 hours of professional training in authentic human connection and peer-based addiction support. It’s a one-of-a-kind opportunity to dig deeper into your own personal growth & healing journey while lifting others up along the way.

to:
> Practical training in active listening: the foundation for more meaningful connection with others. This course teaches you how to better listen to others, and yourself. It’s a one-of-a-kind opportunity to dig deeper into your own personal growth & healing journey while lifting others up along the way. 
> Offered as a 6-week series (email megan@seekhealing.org for next sign-up date) or weekend retreat (click here to see when the next one is)-- link to upcoming events page 

2. change:
> The training is a 16-hour course spanning two days (one day on each of two weekends) and covers techniques on how to offer listening and peer-based support to someone healing from opioid addiction.

to:
> The training takes place over the course of a 6-week series or 2-day weekend retreat, and covers techniques on how to listen supportively to someone healing from opioid addiction (which also involves listening to yourself and learning how to set compassionate boundaries).

