### PR TITLE
Bugs: Miscellaneous cleanup bugfixes

### DIFF
--- a/_data/footer.yaml
+++ b/_data/footer.yaml
@@ -4,7 +4,7 @@ nav:
   - title: Our Programs
     url: /calendar/
   - title: Get Involved
-    url: /get-involved/
+    url: /help/
   - title: Blog
     url: /blog/
 social-media:

--- a/_includes/sections/social-share.html
+++ b/_includes/sections/social-share.html
@@ -32,7 +32,7 @@
             {% when "facebook" %}
             <div class="social-share">
               <a href="https://www.facebook.com/sharer.php?u={{ col.share-post }}">
-                <img class="social-share__image" src="/assets/images/{{ col.share-image }}" alt="{{ col.share-alt }}">
+                <img class="social-share__image img-responsive" src="/assets/images/{{ col.share-image }}" alt="{{ col.share-alt }}">
               </a>
               <div class="social-share__content">
                 <svg class="social-share__content__icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 266.893 266.895">

--- a/_sass/components/_forms.scss
+++ b/_sass/components/_forms.scss
@@ -235,10 +235,14 @@ input[type="checkbox"]:checked ~ .reveal-if-active {
   h3 {
     color: #3e203a;
     font-weight: 500;
-    font-size: 26px;
+    font-size: 18px;
     text-align: center;
     border-bottom: 1px solid #bbb;
     margin-bottom: 0;
+
+    @media screen and (min-width: $screen-sm-min) {
+      font-size: 26px;
+    }
   }
 
   h4 {
@@ -270,7 +274,11 @@ input[type="checkbox"]:checked ~ .reveal-if-active {
     >p {
       color: #777;
       margin: 10px 0;
-      font-size: 16px;
+      font-size: 14px;
+
+      @media screen and (min-width: $screen-sm-min) {
+        font-size: 16px;
+      }
     }
 
     .progress {
@@ -283,9 +291,13 @@ input[type="checkbox"]:checked ~ .reveal-if-active {
     }
 
     .donate-btn-group {
-      margin: 0 10px 0 0;
+      margin: 5px 10px 5px 0;
       height: 35px;
       line-height: 35px;
+
+      @media screen and (min-width: $screen-sm-min) {
+        margin: 0 10px 0 0;
+      }
     }
 
     .form-group {

--- a/_sass/layouts/_sections.scss
+++ b/_sass/layouts/_sections.scss
@@ -151,7 +151,7 @@ section.thin {
 .social-share {
   text-align: right;
   img {
-    max-width: 100%;
+    width: 100%;
   }
 
   .social-share__content {
@@ -171,7 +171,11 @@ section.thin {
 
   .social-share__content__copy {
     display: inline-block;
-    width: calc(100% - 50px);
+    width: calc(100% - 40px);
+
+    @media screen and (min-width: $screen-sm-min) {
+      width: calc(100% - 50px);
+    }
   }
 
 

--- a/assets/js/custom-functions.js
+++ b/assets/js/custom-functions.js
@@ -2,9 +2,12 @@
 $(document).ready(function(){
   if ($('.progress-bar').length) {
     $.get( "https://seekhealing.kindful.com/public/api/v1/campaigns/0efd7b88-00fa-4b91-848e-629db0677a23.json", function( data ) {
-      let raisedAmt = Math.round(data.campaign.total_raised_amount_in_cents / 100);
+      let raisedAmt = 250;
+      if (Math.round(data.campaign.total_raised_amount_in_cents / 100) > 250) {
+        raisedAmt = Math.round(data.campaign.total_raised_amount_in_cents / 100);
+      }
       let goalAmt = Math.round(data.campaign.goal_amount_in_cents / 100);
-      let percentComplete = Math.round(raisedAmt / goalAmt);
+      let percentComplete = Math.floor((raisedAmt / goalAmt) * 100);
       
       $(".label-raised").text("$" + raisedAmt.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ",") + " Raised");
       $(".label-goal").text("$" + goalAmt.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ",") + " Goal");


### PR DESCRIPTION
This PR contains 3 fixes (2 bugs, 1 change) each within their own commit if it is desired to pull any of these out. The fixes are detailed as below:

1. A simple link fix for the 'Get Involved' footer link that was pointing to '/get-involved/' but should be pointing to '/help/'.

2. A change in the fundraiser progress bar logic, so that if the amount raised isn't above $250 yet, it will still use $250 as a baseline minimum.  It should also be noted, that this logic truncates the percentage showing in the meter to an integer as opposed to showing decimal points.  So $250 raised out of $10,000 will show as 2% instead of 3%.

3. Finally, there is some mobile styling cleanup included in the last commit made.  The most egregious styling fix is shown below with a before/after for the holiday fundraiser hero form.

### Mobile styling fixes for Holiday Fundraising form
#### Before

<img width="266" alt="Screen Shot 2019-12-13 at 4 12 54 PM" src="https://user-images.githubusercontent.com/2396774/70832976-917e7200-1dc4-11ea-81a8-9531384802bb.png">

#### After
<img width="273" alt="Screen Shot 2019-12-13 at 4 13 11 PM" src="https://user-images.githubusercontent.com/2396774/70832969-8f1c1800-1dc4-11ea-9ca6-a7e143a484b4.png">