### PR TITLE
Removing donation form from Homepage Hero

### DIFF
--- a/_includes/sections/hero.html
+++ b/_includes/sections/hero.html
@@ -25,45 +25,11 @@
           </div>
           <div class="col-md-6 col-xs-12">
 
-            <div class="infoCard">
-                  
-              <form id="holiday-donate-form" action="/" accept-charset="UTF-8" method="get">
-                <h3><i class="fas fa-sleigh float-left"></i> Holiday fundraising campaign <i class="fas fa-gifts float-right"></i></h3>
-                <p>Giving season is officially underway! December represents one of the most <span class="emphasized-header">critical</span> times of the year for <span class="emphasized-header">SeekHealing</span> and all the people it serves.<p>
-                <p>This holiday season, <span class="emphasized-header">help change lives</span> by giving to help raise $10K and be a part of the solution! Together we can build a world that we all want to live in, rather than escape from.</p>
-
-                <h4>Progress</h4>
-                <div class="goal-progress">
-                  <span class="label-raised"></span>
-                  <span class="label-goal"></span>
-                  <span class="clearfix"></span>
-                </div>
-                <div class="progress">
-                  <div class="progress-bar progress-bar-striped active" role="progressbar" aria-valuenow="" aria-valuemin="0" aria-valuemax="100" style=""></div>
-                </div>
-
-                <h4>Select or enter an amount</h4>
-                <div class="donation-buttons-wrapper" data-defaults="[10, 25, 50, 100]" data-currency="$">
-                      <input class="button donate-btn-group" type="button" value="$50" style="">
-                      <input class="button donate-btn-group" type="button" value="$100" style="">
-                      <input class="button donate-btn-group active" type="button" value="$250" style="">
-                      <input class="button donate-btn-group" type="button" value="$500" style="">
-                </div>
-
-                <div class="form-group">
-                  <label class="sr-only" for="exampleInputAmount">Amount (in dollars)</label>
-                  <div class="input-group">
-                    <div class="input-group-addon">$</div>
-                    <input type="number" class="form-control" id="donate-amount" placeholder="Amount" value="" min=0.01 step=0.01>
-                  </div>
-                </div>
-              
-                <div class="form-group">
-                  <button type="submit" class="btn btn-success">DONATE</button>
-                </div>
-
-              </form>
-
+            <div class="embed-responsive embed-responsive-16by9 hero-vid">
+              <video  class="embed-responsive-item" controls poster="{% if hero.video-preview %}{{ hero.video-preview }}{% endif %}">
+                <source src="{{ hero.video }}" type="video/mp4">
+                Your browser does not support HTML5 video.
+              </video>
             </div>
 
           </div>

--- a/_sections/hero/home.md
+++ b/_sections/hero/home.md
@@ -2,6 +2,8 @@
 type: hero
 title: home
 background: "/assets/images/home-bkgrnd.jpg"
+video: "/downloads/wlos-profile.mp4"
+video-preview: "/assets/images/news-video-preview.png"
 ---
 
 # It's time to <span class="emphasized-header">#RethinkRehab</span>
@@ -9,3 +11,5 @@ background: "/assets/images/home-bkgrnd.jpg"
 ## Healing from addiction through human connection
 
 Be a part of the solution to the overdose epidemic &rarr;
+
+[Donate today!](https://seekhealing.kindful.com/?campaign=1039580&mc_cid=18f09ae341&mc_eid=4a3d1251f9){:target="_blank" class="button cta"}

--- a/_sections/single/elevator-pitch.md
+++ b/_sections/single/elevator-pitch.md
@@ -5,17 +5,6 @@ col-width: thin
 section-bottom-border: true
 ---
 
-<div class="row slider-caption">
-  <div class="col-xs-12">
-    <div class="embed-responsive embed-responsive-16by9 hero-vid">
-      <video  class="embed-responsive-item" controls poster="/assets/images/news-video-preview.png">
-        <source src="/downloads/wlos-profile.mp4" type="video/mp4">
-        Your browser does not support HTML5 video.
-      </video>
-    </div>
-  </div>
-</div>
-
 <span class="emphasized-header">SeekHealing</span> works to prevent drug overdoses by treating both the individual and the community for addiction.
 {:class="heading-two"}
 


### PR DESCRIPTION
This PR removes the donation form entirely from the homepage hero and puts a simple donation button and video back into the hero as it looked similarly prior to the donation form being placed there.  This is per Slack Conversation: https://seekhealing.slack.com/archives/GRKUSLSMV/p1577114769004100

Screen shot of new homepage hero with removal of donation form and donation button/video back in the hero:

<img width="1283" alt="Screen Shot 2019-12-28 at 9 49 08 AM" src="https://user-images.githubusercontent.com/2396774/71545322-cad3e780-2957-11ea-8717-df904358b075.png">
