### PR TITLE
Content: Removing social shares from the home page

### DIFF
--- a/_pages/index.md
+++ b/_pages/index.md
@@ -23,8 +23,6 @@ sections:
     title: "gabor-quote"
   - type: "single"
     title: "home-asheville"
-  - type: "social-share"
-    title: "main-share"
   - type: "subscribe"
   - type: "double"
     title: "testimonial-travis"


### PR DESCRIPTION
This PR removes the social sharing clips from the homepage per: https://seekhealing.slack.com/archives/CE76SU751/p1583337479000300.

I did decide to keep the "main-share" partial in the codebase as well as the styling around this in case this need comes back, but if it is desired to remove all of that from the codebase altogether, let me know.  Really, I'd recommend doing this if the social sharing clips will never come back or be re-utilized in the future. 